### PR TITLE
Make the context optional so that the registry can be used without it… (i.e. standalone)

### DIFF
--- a/Sample/Login/LoginViewControllerProvider.swift
+++ b/Sample/Login/LoginViewControllerProvider.swift
@@ -37,7 +37,7 @@ class LoginViewControllerProvider: ViewControllerProviderObject {
 
     // MARK: Private
 
-    private func createViewController(token: Any, context: Context) -> UIViewController? {
+    private func createViewController(token: Any, context: Context?) -> UIViewController? {
         guard let sampleToken = token as? SampleToken,
             sampleToken.identifier == loginIdentifier,
             let authenticator = authenticator,

--- a/Sample/Logout/LogoutViewControllerProvider.swift
+++ b/Sample/Logout/LogoutViewControllerProvider.swift
@@ -37,9 +37,10 @@ class LogoutViewControllerProvider: ViewControllerProviderObject {
 
     // MARK: Private
 
-    private func createViewController(token: Any, context: Context) -> UIViewController? {
+    private func createViewController(token: Any, context: Context?) -> UIViewController? {
         guard let authenticator = authenticator,
             let sampleToken = token as? SampleToken,
+            let context = context,
             sampleToken.identifier == logoutIdentifier else {
                 return nil
         }

--- a/Sample/ViewController1/ViewController1Provider.swift
+++ b/Sample/ViewController1/ViewController1Provider.swift
@@ -37,7 +37,7 @@ class ViewController1Provider: ViewControllerProviderObject {
 
     // MARK: Private
 
-    private func createViewController(token: Any, context: Context) -> UIViewController? {
+    private func createViewController(token: Any, context: Context?) -> UIViewController? {
         guard let sharedService = sharedService,
             let sampleToken = token as? SampleToken,
             sampleToken.identifier == vc1Identifier,

--- a/Sample/ViewController2/ViewControllerProvider2.swift
+++ b/Sample/ViewController2/ViewControllerProvider2.swift
@@ -37,7 +37,7 @@ class ViewControllerProvider2: ViewControllerProviderObject {
 
     // MARK: Private
 
-    private func createViewController(token: Any, context: Context) -> UIViewController? {
+    private func createViewController(token: Any, context: Context?) -> UIViewController? {
         guard let sharedService = sharedService,
             let sampleToken = token as? SampleToken,
             sampleToken.identifier == vc2Identifier,

--- a/Source/Registry/ViewControllerRegistry.swift
+++ b/Source/Registry/ViewControllerRegistry.swift
@@ -17,7 +17,7 @@ import UIKit
 /// Note that registrants should make sure they don't "overlap" - if more than 1 registrant could potentially return a
 /// VC for the same token, behaviour is undefined - there's no guarantee which will be returned first.
 public class ViewControllerRegistry: NSObject {
-    public typealias RegistryFunction = (Any, Context) -> UIViewController?
+    public typealias RegistryFunction = (Any, Context?) -> UIViewController?
 
     private var registry: [UUID:RegistryFunction] = [:]
 
@@ -31,7 +31,7 @@ public class ViewControllerRegistry: NSObject {
         registry.removeValue(forKey: uuid)
     }
 
-    public func createViewController(from token: Any, context: Context) -> UIViewController? {
+    public func createViewController(from token: Any, context: Context?) -> UIViewController? {
         for function in registry.values {
             if let result = function(token, context) {
                 return result


### PR DESCRIPTION
To use the `ViewControllerRegistry` "standalone" (i.e. without a `Madog` instance) we currently have to use a UI `Context`. This PR makes the `Context` optional so that VCs can be created that don't care about `Contexts`.