### PR TITLE
Drop navigation token

### DIFF
--- a/Source/Navigation/NavigationContexts.swift
+++ b/Source/Navigation/NavigationContexts.swift
@@ -133,7 +133,7 @@ public extension ModalContext {
 
 public protocol ForwardBackNavigationContext: AnyObject {
 	@discardableResult
-	func navigateForward(token: Any, animated: Bool) -> NavigationToken?
+	func navigateForward(token: Any, animated: Bool) -> Bool
 	@discardableResult
 	func navigateBack(animated: Bool) -> Bool
 	@discardableResult

--- a/Source/UI/NavigationUI.swift
+++ b/Source/UI/NavigationUI.swift
@@ -31,14 +31,14 @@ internal class NavigationUI<Token>: MadogSingleUIContainer<Token>, ForwardBackNa
 
 	// MARK: - ForwardBackNavigationContext
 
-	internal func navigateForward(token: Any, animated: Bool) -> NavigationToken? {
+	internal func navigateForward(token: Any, animated: Bool) -> Bool {
 		guard let token = token as? Token,
 			let viewController = registry.createViewController(from: token, context: self) else {
-			return nil
+			return false
 		}
 
 		navigationController.pushViewController(viewController, animated: animated)
-		return createNavigationToken(for: viewController)
+		return true
 	}
 
 	internal func navigateBack(animated: Bool) -> Bool {

--- a/Source/UI/TabBarNavigationUI.swift
+++ b/Source/UI/TabBarNavigationUI.swift
@@ -30,15 +30,15 @@ internal class TabBarNavigationUI<Token>: MadogMultiUIContainer<Token>, ForwardB
 
 	// MARK: - ForwardBackNavigationContext
 
-	internal func navigateForward(token: Any, animated: Bool) -> NavigationToken? {
+	internal func navigateForward(token: Any, animated: Bool) -> Bool {
 		guard let token = token as? Token,
 			let toViewController = registry.createViewController(from: token, context: self),
 			let navigationController = tabBarController.selectedViewController as? UINavigationController else {
-			return nil
+			return false
 		}
 
 		navigationController.pushViewController(toViewController, animated: animated)
-		return createNavigationToken(for: viewController)
+		return true
 	}
 
 	internal func navigateBack(animated: Bool) -> Bool {

--- a/Source/UIContainer/MadogUIContainer.swift
+++ b/Source/UIContainer/MadogUIContainer.swift
@@ -65,18 +65,18 @@ open class MadogUIContainer<Token>: MadogUIContext, ModalContext {
 						  animated: Bool,
 						  completion: (() -> Void)?) -> NavigationToken? {
 		guard let token = token as? Token,
-			let viewController = registry.createViewController(from: token, context: self) else {
+			let presentedViewController = registry.createViewController(from: token, context: self) else {
 			return nil
 		}
 
-		let sourceViewController = fromViewController ?? self.viewController
-		sourceViewController.madog_presentModally(viewController: viewController,
-												  presentationStyle: presentationStyle,
-												  transitionStyle: transitionStyle,
-												  popoverAnchor: popoverAnchor,
-												  animated: animated,
-												  completion: completion)
-		return createNavigationToken(for: viewController)
+		let presentingViewController = fromViewController ?? viewController
+		presentingViewController.madog_presentModally(viewController: presentedViewController,
+													  presentationStyle: presentationStyle,
+													  transitionStyle: transitionStyle,
+													  popoverAnchor: popoverAnchor,
+													  animated: animated,
+													  completion: completion)
+		return createNavigationToken(for: presentedViewController)
 	}
 
 	public func openModal<VC: UIViewController>(identifier: SingleUIIdentifier<VC>,
@@ -92,13 +92,14 @@ open class MadogUIContainer<Token>: MadogUIContext, ModalContext {
 			return nil
 		}
 
-		let sourceViewController = fromViewController ?? viewController
-		sourceViewController.madog_presentModally(viewController: container.viewController,
-												  presentationStyle: presentationStyle,
-												  transitionStyle: transitionStyle,
-												  popoverAnchor: popoverAnchor,
-												  animated: animated,
-												  completion: completion)
+		let presentingViewController = fromViewController ?? viewController
+		let presentedViewController = container.viewController
+		presentingViewController.madog_presentModally(viewController: presentedViewController,
+													  presentationStyle: presentationStyle,
+													  transitionStyle: transitionStyle,
+													  popoverAnchor: popoverAnchor,
+													  animated: animated,
+													  completion: completion)
 		return container
 	}
 
@@ -115,13 +116,14 @@ open class MadogUIContainer<Token>: MadogUIContext, ModalContext {
 			return nil
 		}
 
-		let sourceViewController = fromViewController ?? viewController
-		sourceViewController.madog_presentModally(viewController: container.viewController,
-												  presentationStyle: presentationStyle,
-												  transitionStyle: transitionStyle,
-												  popoverAnchor: popoverAnchor,
-												  animated: animated,
-												  completion: completion)
+		let presentingViewController = fromViewController ?? viewController
+		let presentedViewController = container.viewController
+		presentingViewController.madog_presentModally(viewController: presentedViewController,
+													  presentationStyle: presentationStyle,
+													  transitionStyle: transitionStyle,
+													  popoverAnchor: popoverAnchor,
+													  animated: animated,
+													  completion: completion)
 		return container
 	}
 

--- a/Tests/MadogTests.swift
+++ b/Tests/MadogTests.swift
@@ -26,6 +26,18 @@ class MadogTests: XCTestCase {
 		super.tearDown()
 	}
 
+	func testMadogKeepsStrongReferenceToCurrentContext() {
+		let window = UIWindow()
+		let identifier = SingleUIIdentifier.createNavigationControllerIdentifier()
+
+		weak var context1 = madog.renderUI(identifier: identifier, token: "match", in: window)
+		XCTAssertNotNil(context1)
+
+		weak var context2 = madog.renderUI(identifier: identifier, token: "match", in: window)
+		XCTAssertNil(context1)
+		XCTAssertNotNil(context2)
+	}
+
 	func testMadogDelegateHeldWeakly() {
 		var delegate: MadogTestDelegate? = MadogTestDelegate()
 		madog.delegate = delegate

--- a/Tests/UIContainer/MadogUIContainerTests.swift
+++ b/Tests/UIContainer/MadogUIContainerTests.swift
@@ -147,7 +147,7 @@ private class TestResolver: Resolver<String> {
 }
 
 private class TestViewControllerProvider: BaseViewControllerProvider {
-	override func createViewController(token: String, context: Context) -> UIViewController? {
+	override func createViewController(token: String, context _: Context) -> UIViewController? {
 		let viewController = TestViewController()
 		viewController.title = token
 		viewController.label.text = token


### PR DESCRIPTION
Return a `Bool` from `navigateForward`

** API BREAKING CHANGE **