### PR TITLE
Use token type in ui subclass

### DIFF
--- a/SampleApp/SampleApp/AppDelegate.swift
+++ b/SampleApp/SampleApp/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         madog.resolve(resolver: SampleResolver(), launchOptions: launchOptions)
-        let result = madog.addUICreationFunction(identifier: splitViewControllerIdentifier) { SplitUI(registry: $0, tokenData: $1) }
+        let result = madog.addUICreationFunction(identifier: splitViewControllerIdentifier, function: SplitUI.init(registry:primaryToken:secondaryToken:))
         guard result == true else {
             return false
         }

--- a/SampleApp/SampleApp/Custom UI/SplitUI.swift
+++ b/SampleApp/SampleApp/Custom UI/SplitUI.swift
@@ -17,12 +17,10 @@ protocol SplitContext: Context {
 class SplitUI<Token>: MadogModalUIContainer<Token>, SplitContext {
     private let splitController = UISplitViewController()
 
-    init?(registry: Registry<Token>, tokenData: SplitSingleUITokenData) {
+    init?(registry: Registry<Token>, primaryToken: Token, secondaryToken: Token) {
         super.init(registry: registry, viewController: splitController)
 
-        guard let primaryToken = tokenData.primaryToken as? Token,
-            let secondaryToken = tokenData.secondaryToken as? Token,
-            let primaryViewController = registry.createViewController(from: primaryToken, context: self),
+        guard let primaryViewController = registry.createViewController(from: primaryToken, context: self),
             let secondaryViewController = registry.createViewController(from: secondaryToken, context: self) else {
             return nil
         }

--- a/Source/UI/BasicUI.swift
+++ b/Source/UI/BasicUI.swift
@@ -11,11 +11,10 @@ import UIKit
 internal class BasicUI<Token>: MadogModalUIContainer<Token> {
     private let containerController = BasicUIContainerViewController()
 
-    internal init?(registry: Registry<Token>, tokenData: SingleUITokenData) {
+    internal init?(registry: Registry<Token>, token: Token) {
         super.init(registry: registry, viewController: containerController)
 
-        guard let token = tokenData.token as? Token,
-            let viewController = registry.createViewController(from: token, context: self) else {
+        guard let viewController = registry.createViewController(from: token, context: self) else {
             return nil
         }
 

--- a/Source/UI/NavigationUI.swift
+++ b/Source/UI/NavigationUI.swift
@@ -14,11 +14,10 @@ import UIKit
 internal class NavigationUI<Token>: MadogNavigatingModalUIContainer<Token> {
     private let navigationController = UINavigationController()
 
-    internal init?(registry: Registry<Token>, tokenData: SingleUITokenData) {
+    internal init?(registry: Registry<Token>, token: Token) {
         super.init(registry: registry, viewController: navigationController)
 
-        guard let token = tokenData.token as? Token,
-            let viewController = registry.createViewController(from: token, context: self) else {
+        guard let viewController = registry.createViewController(from: token, context: self) else {
             return nil
         }
 

--- a/Source/UI/TabBarNavigationUI.swift
+++ b/Source/UI/TabBarNavigationUI.swift
@@ -14,12 +14,8 @@ import UIKit
 internal class TabBarNavigationUI<Token>: MadogNavigatingModalUIContainer<Token>, MultiContext {
     private let tabBarController = UITabBarController()
 
-    internal init?(registry: Registry<Token>, tokenData: MultiUITokenData) {
+    internal init(registry: Registry<Token>, tokens: [Token]) {
         super.init(registry: registry, viewController: tabBarController)
-
-        guard let tokens = tokenData.tokens as? [Token] else {
-            return nil
-        }
 
         let viewControllers = tokens.compactMap { registry.createViewController(from: $0, context: self) }
             .map { UINavigationController(rootViewController: $0) }

--- a/Source/UI/TabBarUI.swift
+++ b/Source/UI/TabBarUI.swift
@@ -11,15 +11,10 @@ import UIKit
 internal class TabBarUI<Token>: MadogModalUIContainer<Token>, MultiContext {
     private let tabBarController = UITabBarController()
 
-    internal init?(registry: Registry<Token>, tokenData: MultiUITokenData) {
+    internal init(registry: Registry<Token>, tokens: [Token]) {
         super.init(registry: registry, viewController: tabBarController)
 
-        guard let tokens = tokenData.tokens as? [Token] else {
-            return nil
-        }
-
         let viewControllers = tokens.compactMap { registry.createViewController(from: $0, context: self) }
-            .map { UINavigationController(rootViewController: $0) }
 
         tabBarController.viewControllers = viewControllers
     }

--- a/Source/UIContainer/MadogUIContainerFactory.swift
+++ b/Source/UIContainer/MadogUIContainerFactory.swift
@@ -23,10 +23,10 @@ internal class MadogUIContainerFactory<Token> {
     internal init(registry: Registry<Token>) {
         self.registry = registry
 
-        _ = addUICreationFunction(identifier: basicIdentifier, function: BasicUI<Token>.init(registry:token:))
-        _ = addUICreationFunction(identifier: navigationIdentifier, function: NavigationUI<Token>.init(registry:token:))
-        _ = addUICreationFunction(identifier: tabBarIdentifier, function: TabBarUI<Token>.init(registry:tokens:))
-        _ = addUICreationFunction(identifier: tabBarNavigationIdentifier, function: TabBarNavigationUI<Token>.init(registry:tokens:))
+        _ = addUICreationFunction(identifier: basicIdentifier, function: BasicUI.init(registry:token:))
+        _ = addUICreationFunction(identifier: navigationIdentifier, function: NavigationUI.init(registry:token:))
+        _ = addUICreationFunction(identifier: tabBarIdentifier, function: TabBarUI.init(registry:tokens:))
+        _ = addUICreationFunction(identifier: tabBarNavigationIdentifier, function: TabBarNavigationUI.init(registry:tokens:))
     }
 
     internal func addUICreationFunction(identifier: String, function: @escaping SingleVCUIRegistryFunction<Token>) -> Bool {

--- a/Source/UIContainer/MadogUIContainerFactory.swift
+++ b/Source/UIContainer/MadogUIContainerFactory.swift
@@ -25,10 +25,10 @@ internal class MadogUIContainerFactory<Token> {
     internal init(registry: Registry<Token>) {
         self.registry = registry
 
-        _ = addUICreationFunction(identifier: basicIdentifier) { BasicUI<Token>(registry: $0, tokenData: $1) }
-        _ = addUICreationFunction(identifier: navigationIdentifier) { NavigationUI<Token>(registry: $0, tokenData: $1) }
-        _ = addUICreationFunction(identifier: tabBarIdentifier) { TabBarUI<Token>(registry: $0, tokenData: $1) }
-        _ = addUICreationFunction(identifier: tabBarNavigationIdentifier) { TabBarNavigationUI<Token>(registry: $0, tokenData: $1) }
+        _ = addUICreationFunction(identifier: basicIdentifier, function: BasicUI<Token>.init(registry:tokenData:))
+        _ = addUICreationFunction(identifier: navigationIdentifier, function: NavigationUI<Token>.init(registry:tokenData:))
+        _ = addUICreationFunction(identifier: tabBarIdentifier, function: TabBarUI<Token>.init(registry:tokenData:))
+        _ = addUICreationFunction(identifier: tabBarNavigationIdentifier, function: TabBarNavigationUI<Token>.init(registry:tokenData:))
     }
 
     internal func addUICreationFunction(identifier: String, function: @escaping SingleVCUIRegistryFunction<Token>) -> Bool {


### PR DESCRIPTION
The factory now takes care of transforming `TokenData` into strongly types `Token`s to pass to the container creation functions.