### PR TITLE
Fixes dismiss modal with completion

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "cerihughes/Provident" "3.0.0"
-github "kif-framework/KIF" "v3.7.9"
+github "kif-framework/KIF" "v3.7.11"

--- a/Source/UIContainer/MadogModalUIContainer.swift
+++ b/Source/UIContainer/MadogModalUIContainer.swift
@@ -74,8 +74,10 @@ open class MadogModalUIContainer<Token>: MadogUIContainer, ModalContext {
             closeContext(presentedViewController: presentedPresentedViewController, animated: animated)
         }
 
-        presentedViewController.dismiss(animated: animated, completion: completion)
-        delegate?.releaseContext(for: presentedViewController)
+		if presentedViewController.parent == nil {
+			presentedViewController.dismiss(animated: animated, completion: completion)
+		}
+		delegate?.releaseContext(for: presentedViewController)
     }
 
     public final func createModalToken(viewController: UIViewController, context: Context?) -> ModalToken {


### PR DESCRIPTION
The existing code calls `dismiss` recursively on all children of the root view controller (and their children’s children, etc), causing UIKit to attempt to potentially dismiss many view controllers at once. After iOS 12 this seems fine, but it’s broken in iOS 12.

The fix only calls dismiss on the root view controller, which will dismiss all view controllers and correctly call the completion when done.