### PR TITLE
Minor API changes

### DIFF
--- a/Source/Contexts/ModalContext.swift
+++ b/Source/Contexts/ModalContext.swift
@@ -13,7 +13,6 @@ public protocol ModalContext: AnyObject {
     @discardableResult
     func openModal<VC, TD>(identifier: MadogUIIdentifier<VC, TD>,
                            tokenData: TD,
-                           from fromViewController: UIViewController?,
                            presentationStyle: UIModalPresentationStyle?,
                            transitionStyle: UIModalTransitionStyle?,
                            popoverAnchor: Any?,
@@ -32,7 +31,6 @@ public extension ModalContext {
     @discardableResult
     func openModal<VC, TD>(identifier: MadogUIIdentifier<VC, TD>,
                            tokenData: TD,
-                           from fromViewController: UIViewController? = nil,
                            presentationStyle: UIModalPresentationStyle? = nil,
                            transitionStyle: UIModalTransitionStyle? = nil,
                            popoverAnchor: Any? = nil,
@@ -41,7 +39,6 @@ public extension ModalContext {
                            completion: CompletionBlock? = nil) -> ModalToken? where VC: UIViewController, TD: TokenData {
         openModal(identifier: identifier,
                   tokenData: tokenData,
-                  from: fromViewController,
                   presentationStyle: presentationStyle,
                   transitionStyle: transitionStyle,
                   popoverAnchor: popoverAnchor,

--- a/Source/Contexts/ModalContext.swift
+++ b/Source/Contexts/ModalContext.swift
@@ -57,14 +57,14 @@ public extension ModalContext {
 }
 
 public protocol ModalToken {
-    var context: Context? { get }
+    var context: Context { get }
 }
 
 internal class ModalTokenImplementation: ModalToken {
     internal let viewController: UIViewController
-    weak var context: Context?
+    let context: Context
 
-    internal init(viewController: UIViewController, context: Context? = nil) {
+    internal init(viewController: UIViewController, context: Context) {
         self.viewController = viewController
         self.context = context
     }

--- a/Source/UIContainer/MadogModalUIContainer.swift
+++ b/Source/UIContainer/MadogModalUIContainer.swift
@@ -76,7 +76,7 @@ open class MadogModalUIContainer<Token>: MadogUIContainer, ModalContext {
         delegate?.releaseContext(for: presentedViewController)
     }
 
-    public final func createModalToken(viewController: UIViewController, context: Context?) -> ModalToken {
+    public final func createModalToken(viewController: UIViewController, context: Context) -> ModalToken {
         ModalTokenImplementation(viewController: viewController, context: context)
     }
 }

--- a/Source/UIContainer/MadogModalUIContainer.swift
+++ b/Source/UIContainer/MadogModalUIContainer.swift
@@ -28,7 +28,6 @@ open class MadogModalUIContainer<Token>: MadogUIContainer, ModalContext {
     // swiftlint:disable function_parameter_count
     public func openModal<VC, TD>(identifier: MadogUIIdentifier<VC, TD>,
                                   tokenData: TD,
-                                  from fromViewController: UIViewController?,
                                   presentationStyle: UIModalPresentationStyle?,
                                   transitionStyle: UIModalTransitionStyle?,
                                   popoverAnchor: Any?,
@@ -40,9 +39,8 @@ open class MadogModalUIContainer<Token>: MadogUIContainer, ModalContext {
             return nil
         }
 
-        let presentingViewController = fromViewController ?? viewController
         let presentedViewController = container.viewController
-        let result = modalPresentation.presentModally(presenting: presentingViewController,
+        let result = modalPresentation.presentModally(presenting: viewController,
                                                       modal: presentedViewController,
                                                       presentationStyle: presentationStyle,
                                                       transitionStyle: transitionStyle,

--- a/Tests/UIContainer/MadogUIContainerTests.swift
+++ b/Tests/UIContainer/MadogUIContainerTests.swift
@@ -271,7 +271,7 @@ class MadogUIContainerTests: MadogKIFTestCase {
 
         let modalContext = modalToken!.context
         weak var completionExpectation = expectation(description: "Completion fired")
-        modalContext?.close(animated: true, completion: { completionExpectation?.fulfill() })
+        modalContext.close(animated: true, completion: { completionExpectation?.fulfill() })
         waitForExpectations(timeout: 10.0)
     }
 


### PR DESCRIPTION
- `ModalToken` now has a non optional `Context`
- Can no longer specify a `fromViewController` when opening a modal